### PR TITLE
update to msal2.3.1 for hotfix

### DIFF
--- a/device-code-flow-console/MyInformation.cs
+++ b/device-code-flow-console/MyInformation.cs
@@ -74,6 +74,7 @@ namespace device_code_flow_console
                 Console.ResetColor();
                 await CallWebApiAndDisplayResultASync(WebApiUrlMyManager, authenticationResult);
             }
+            Console.ReadKey();
         }
 
         /// <summary>

--- a/device-code-flow-console/device-code-flow-console.csproj
+++ b/device-code-flow-console/device-code-flow-console.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="2.2.0-preview" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="2.3.1-preview" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
 


### PR DESCRIPTION
- console was not staying open, so added a console.readkey()